### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/scripts/fetch_stream.py
+++ b/scripts/fetch_stream.py
@@ -22,6 +22,7 @@ import os
 import re
 import sys
 from datetime import datetime, date
+from urllib.parse import urlparse
 
 try:
     import feedparser
@@ -167,11 +168,16 @@ def fetch_publications():
                 continue
             date_str = f"{year_m.group(1)}-01-01"
 
-            # URL — prefer doi.org, else first http link
+            # URL — prefer doi.org host, else first http link
             urls = re.findall(r'\((https?://[^)]+)\)', block)
             if not urls:
                 continue
-            doi_urls = [u for u in urls if 'doi.org' in u]
+
+            def _is_doi_url(u: str) -> bool:
+                host = urlparse(u).hostname or ""
+                return host == "doi.org" or host.endswith(".doi.org")
+
+            doi_urls = [u for u in urls if _is_doi_url(u)]
             url = doi_urls[0] if doi_urls else urls[0]
 
             # Venue — first non-title, non-author, non-link line


### PR DESCRIPTION
Potential fix for [https://github.com/pizzato/pizzato.github.io/security/code-scanning/2](https://github.com/pizzato/pizzato.github.io/security/code-scanning/2)

Use URL parsing and validate the hostname field, instead of substring matching the raw URL string.

Best fix in this file:
- In `scripts/fetch_stream.py`, import `urlparse` from `urllib.parse`.
- Replace line 174 logic with a helper predicate that:
  - Parses each URL via `urlparse(u)`.
  - Reads `parsed.hostname` (normalized lowercase by `urlparse`).
  - Accepts exact `doi.org` and optionally subdomains ending in `.doi.org`.
This preserves existing behavior (“prefer DOI URL if present, otherwise first URL”) while removing the incomplete sanitization pattern.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
