### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_site.yml
+++ b/.github/workflows/build_site.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/pizzato/pizzato.github.io/security/code-scanning/1](https://github.com/pizzato/pizzato.github.io/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege defaults unless overridden.  
For this workflow, the best non-functional-change fix is:

- In `.github/workflows/build_site.yml`, add:
  - `permissions:`
  - `  contents: read`
- Place it near the top-level keys (e.g., after `on:` block and before `jobs:`), so it applies globally.

This documents intended token access and prevents accidental privilege expansion if repository defaults change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
